### PR TITLE
Complete header

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ This is just a CMake wrapper for [kseq.h](http://lh3lh3.users.sourceforge.net/ks
 #include <kseq/kseq.h>
 ```
 
+#### Retreive the whole header comment
+
+In Fasta headers, `kseq.h` can return two parts.
+
+1- `kseqObj->name.s`: The sequence id, Or technincally speaking, the first word before the delimiter (`\t`, `\s`).
+2- `kseqObj->comment.s`: The rest of the header after the delimiter.
+
+To retreive the whole header you would do something like: `kseqObj->name.s + delimiter + kseqObj->comment.s`. The delimiter here is unknown due to its variablity in the sequence files.
+
+To get the full comment, just put the following line inside the main function, or your target function.
+
+```cpp
+KS_FULL_COMMENT = true; 
+```
+
+Now the `kseqObj->comment.s` = `delimiter` + the rest of the header line.
+
 ### Method 1 (add_subdirectory)
 
 ```cmake

--- a/include/kseq/kseq.h
+++ b/include/kseq/kseq.h
@@ -37,6 +37,10 @@
 #define KS_SEP_LINE  2 // line separator: "\n" (Unix) or "\r\n" (Windows)
 #define KS_SEP_MAX   2
 
+// To enable 
+#define KS_FULL_COMMENT delimeter_size
+bool delimeter_size = 1;
+
 #define __KS_TYPE(type_t) \
 	typedef struct __kstream_t { \
 		unsigned char *buf; \
@@ -128,7 +132,7 @@ typedef struct __kstring_t {
 			gotany = 1; \
 			memcpy(str->s + str->l, ks->buf + ks->begin, i - ks->begin); \
 			str->l = str->l + (i - ks->begin); \
-			ks->begin = i + 1; \
+			ks->begin = i + !KS_FULL_COMMENT; \
 			if (i < ks->end) { \
 				if (dret) *dret = ks->buf[i]; \
 				break; \


### PR DESCRIPTION
Example of retrieving the complete original header from Fasta file.

```cpp
#include <zlib.h>
#include <stdio.h>
#include "kseq.h"

KSEQ_INIT(gzFile, gzread)

int main(int argc, char *argv[])
{
  gzFile fp;
  kseq_t *seq;
  int l;
  KS_FULL_COMMENT = true; // <--- HERE IS THE UPDATE
  fp = gzopen(argv[1], "r");
  seq = kseq_init(fp);


  while ((l = kseq_read(seq)) >= 0) {
        printf("name: %s\n", seq->name.s);
        if (seq->comment.l) printf("comment: %s\n", seq->comment.s);
        printf("seq: %s\n", seq->seq.s);
        if (seq->qual.l) printf("qual: %s\n", seq->qual.s);
  }


  kseq_destroy(seq);
  gzclose(fp);
  return 0;
}
```